### PR TITLE
ci: Go versionをstableに更新

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v5
       with:
-        go-version: '1.21'
+        go-version: 'stable'
         
     - name: Cache Go modules
       uses: actions/cache@v4
@@ -90,7 +90,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v5
       with:
-        go-version: '1.21'
+        go-version: 'stable'
         
     - name: Run Gosec Security Scanner
       run: |
@@ -113,7 +113,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v5
       with:
-        go-version: '1.21'
+        go-version: 'stable'
         
     - name: Check for known vulnerabilities
       run: |

--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -18,7 +18,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v5
       with:
-        go-version: '1.21'
+        go-version: 'stable'
         
     - name: Cache Go modules
       uses: actions/cache@v4
@@ -70,7 +70,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v5
       with:
-        go-version: '1.21'
+        go-version: 'stable'
         
     - name: Install SQLite
       run: sudo apt-get update && sudo apt-get install -y sqlite3
@@ -103,7 +103,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v5
       with:
-        go-version: '1.21'
+        go-version: 'stable'
         
     - name: Install dependencies
       run: |


### PR DESCRIPTION
## Summary
CI/CDワークフローのGo versionを固定版からstableに変更

## 変更内容
- **ci.yml**: `go-version: '1.21'` → `go-version: 'stable'`
- **quality.yml**: `go-version: '1.21'` → `go-version: 'stable'`

## メリット
- **常に最新版**: GitHubが提供する最新の安定版Goを自動使用
- **セキュリティ向上**: 最新のセキュリティパッチを適用
- **パフォーマンス向上**: 最新の最適化機能を利用
- **メンテナンス軽減**: バージョン固定による管理負担を削減

## テスト計画
- [x] ワークフロー構文の確認
- [ ] CIパイプラインの動作確認（PR作成後）

🤖 Generated with [Claude Code](https://claude.ai/code)