### PR TITLE
update: Go version 1.21 → 1.24に更新

### DIFF
--- a/backend/go.mod
+++ b/backend/go.mod
@@ -1,6 +1,6 @@
 module lazychef
 
-go 1.21
+go 1.24
 
 require (
 	github.com/gin-gonic/gin v1.10.1


### PR DESCRIPTION
## Summary
go.modのGoバージョンを1.21から1.24に更新

## 変更内容
- **go.mod**: `go 1.21` → `go 1.24`
- **依存関係**: `go mod tidy`で最新化

## バージョン選択理由
- Go 1.25が最新版だが、golangci-lintが未対応
- Go 1.24は安定しており、全ツールがサポート済み
- セキュリティとパフォーマンス向上を実現

## テスト結果
- [x] `make quality` 正常動作
- [x] 全テストが通過
- [x] リンターエラーなし
- [x] 依存関係の整合性確認済み

## 影響
- 新しいGo機能とセキュリティパッチを利用可能
- パフォーマンスの向上
- 後方互換性は維持

🤖 Generated with [Claude Code](https://claude.ai/code)