### PR TITLE
ci: dependency-checkジョブを削除

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -103,19 +103,3 @@ jobs:
       with:
         sarif_file: gosec-results.sarif
 
-  dependency-check:
-    runs-on: ubuntu-latest
-    
-    steps:
-    - name: Checkout code
-      uses: actions/checkout@v4
-      
-    - name: Set up Go
-      uses: actions/setup-go@v5
-      with:
-        go-version: 'stable'
-        
-    - name: Check for known vulnerabilities
-      run: |
-        cd backend
-        go list -json -m all | docker run --rm -i sonatypecommunity/nancy:latest sleuth


### PR DESCRIPTION
## Summary
CIワークフローからdependency-checkジョブを削除

## 変更内容
- **ci.yml**: dependency-checkジョブ全体を削除
- 不要な依存関係脆弱性チェックを除去

## 削除理由
- **Dependabotで自動化済み**: 週1回の依存関係チェックが自動実行
- **重複機能の排除**: 手動チェックが不要
- **CI実行時間短縮**: リソース節約とパフォーマンス向上
- **セキュリティは維持**: gosecによるセキュリティスキャンは継続

## 残存するセキュリティ機能
- ✅ **gosec**: セキュリティスキャン継続
- ✅ **Dependabot**: 自動依存関係更新
- ✅ **GitHub Security**: 脆弱性アラート

## 影響
- CI実行時間の短縮
- リソース使用量削減
- セキュリティレベルは維持

🤖 Generated with [Claude Code](https://claude.ai/code)