### PR TITLE
feat: レシピページにレシピ詳細モーダル機能を実装

### DIFF
--- a/frontend/src/pages/RecipeListPage.tsx
+++ b/frontend/src/pages/RecipeListPage.tsx
@@ -1,6 +1,7 @@
 import React, { useState } from 'react';
 import RecipeSearch from '../components/recipe/RecipeSearch';
 import RecipeCard from '../components/recipe/RecipeCard';
+import RecipeDetailModal from '../components/recipe/RecipeDetailModal';
 import LoadingSpinner from '../components/common/LoadingSpinner';
 import { useRecipes } from '../hooks/useRecipes';
 import type { Recipe } from '../types';
@@ -16,6 +17,10 @@ const RecipeListPage: React.FC = () => {
     maxCookingTime: null,
     minLazinessScore: null,
   });
+
+  // モーダル状態管理
+  const [selectedRecipe, setSelectedRecipe] = useState<Recipe | null>(null);
+  const [isModalOpen, setIsModalOpen] = useState(false);
 
   const recipesPerPage = 12;
   const totalPages = Math.ceil(total / recipesPerPage);
@@ -33,7 +38,14 @@ const RecipeListPage: React.FC = () => {
 
   const handleRecipeClick = (recipe: Recipe) => {
     console.log('Recipe clicked:', recipe);
-    // Phase 3でレシピ詳細ページに遷移する機能を実装予定
+    setSelectedRecipe(recipe);
+    setIsModalOpen(true);
+  };
+
+  // モーダルクローズ
+  const handleModalClose = () => {
+    setIsModalOpen(false);
+    setSelectedRecipe(null);
   };
 
   const hasActiveFilters = 
@@ -181,6 +193,13 @@ const RecipeListPage: React.FC = () => {
           )}
         </>
       )}
+
+      {/* レシピ詳細モーダル */}
+      <RecipeDetailModal
+        isOpen={isModalOpen}
+        onClose={handleModalClose}
+        recipe={selectedRecipe}
+      />
     </div>
   );
 };


### PR DESCRIPTION
## Summary
- RecipeListPageにRecipeDetailModalコンポーネントを統合し、レシピクリック機能を実装
- ユーザーがレシピカードをクリックすると詳細モーダルが表示される機能を追加
- ESCキーでモーダルを閉じる機能も含む

## 変更内容
- `RecipeListPage.tsx` に `RecipeDetailModal` コンポーネントをインポート
- モーダル状態管理（`selectedRecipe`, `isModalOpen`）を追加
- `handleRecipeClick` 関数を実装してモーダル表示機能を追加
- `handleModalClose` 関数でモーダル閉じる機能を実装

## Test plan
- [x] レシピカードクリックでモーダルが表示されることを確認
- [x] モーダルに正しいレシピ詳細情報が表示されることを確認  
- [x] ESCキーでモーダルが閉じることを確認
- [x] 検索機能が正常に動作することを確認
- [x] Playwright での動作確認完了
- [x] `make quality` でのビルドとテスト成功

🤖 Generated with [Claude Code](https://claude.ai/code)