### PR TITLE
feat: Issue #57 材料量の適切な集約機能実装

### DIFF
--- a/backend/internal/handlers/meal_plan_handler_test.go
+++ b/backend/internal/handlers/meal_plan_handler_test.go
@@ -18,8 +18,8 @@ func TestMealPlanHandler_CreateMealPlan(t *testing.T) {
 	// Setup Gin in test mode
 	gin.SetMode(gin.TestMode)
 
-	// Create mock meal planner service
-	mockPlanner := &services.MealPlannerService{}
+	// Create properly initialized meal planner service
+	mockPlanner := services.NewMealPlannerService(nil, nil)
 	handler := NewMealPlanHandler(mockPlanner)
 
 	// Create test request
@@ -52,7 +52,7 @@ func TestMealPlanHandler_CreateMealPlan(t *testing.T) {
 func TestMealPlanHandler_CreateMealPlan_InvalidJSON(t *testing.T) {
 	gin.SetMode(gin.TestMode)
 
-	mockPlanner := &services.MealPlannerService{}
+	mockPlanner := services.NewMealPlannerService(nil, nil)
 	handler := NewMealPlanHandler(mockPlanner)
 
 	w := httptest.NewRecorder()

--- a/backend/internal/services/ingredient_aggregator.go
+++ b/backend/internal/services/ingredient_aggregator.go
@@ -1,0 +1,255 @@
+package services
+
+import (
+	"fmt"
+	"regexp"
+	"strconv"
+	"strings"
+)
+
+// IngredientQuantity represents a parsed ingredient quantity
+type IngredientQuantity struct {
+	Amount float64
+	Unit   string
+}
+
+// IngredientAggregator handles ingredient amount aggregation
+type IngredientAggregator struct {
+	unitConversions map[string]map[string]float64
+}
+
+// NewIngredientAggregator creates a new ingredient aggregator
+func NewIngredientAggregator() *IngredientAggregator {
+	return &IngredientAggregator{
+		unitConversions: initUnitConversions(),
+	}
+}
+
+// initUnitConversions initializes unit conversion table
+func initUnitConversions() map[string]map[string]float64 {
+	return map[string]map[string]float64{
+		// Weight conversions (to grams)
+		"weight": {
+			"g":   1.0,
+			"グラム": 1.0,
+			"kg":  1000.0,
+			"キロ":  1000.0,
+		},
+		// Volume conversions (to ml)
+		"volume": {
+			"ml":     1.0,
+			"ミリリットル": 1.0,
+			"l":      1000.0,
+			"リットル":   1000.0,
+			"cc":     1.0,
+			"大さじ":    15.0,
+			"小さじ":    5.0,
+			"カップ":    200.0,
+			"合":      180.0,
+		},
+		// Count (pieces)
+		"count": {
+			"個":   1.0,
+			"本":   1.0,
+			"枚":   1.0,
+			"切れ":  1.0,
+			"かけ":  1.0,
+			"パック": 1.0,
+			"袋":   1.0,
+			"缶":   1.0,
+		},
+	}
+}
+
+// ParseQuantity parses an amount string into quantity and unit
+func (a *IngredientAggregator) ParseQuantity(amountStr string) (*IngredientQuantity, error) {
+	if amountStr == "" {
+		return nil, fmt.Errorf("empty amount string")
+	}
+
+	// Remove whitespace
+	amountStr = strings.TrimSpace(amountStr)
+
+	// Handle special cases
+	if strings.Contains(amountStr, "適量") || strings.Contains(amountStr, "少々") {
+		return &IngredientQuantity{Amount: 0, Unit: "適量"}, nil
+	}
+
+	// Try different patterns for Japanese-style quantities
+	// Pattern 1: "大さじ1" style (unit first, then number)
+	unitFirstRe := regexp.MustCompile(`^([^\d]+)(\d+\.?\d*)$`)
+	unitFirstMatches := unitFirstRe.FindStringSubmatch(amountStr)
+
+	if len(unitFirstMatches) == 3 {
+		amount, err := strconv.ParseFloat(unitFirstMatches[2], 64)
+		if err == nil {
+			unit := strings.TrimSpace(unitFirstMatches[1])
+			return &IngredientQuantity{Amount: amount, Unit: unit}, nil
+		}
+	}
+
+	// Pattern 2: "1大さじ" style (number first, then unit)
+	numberFirstRe := regexp.MustCompile(`^(\d+\.?\d*)\s*(.*)$`)
+	numberFirstMatches := numberFirstRe.FindStringSubmatch(amountStr)
+
+	if len(numberFirstMatches) != 3 {
+		return &IngredientQuantity{Amount: 0, Unit: "適量"}, nil
+	}
+
+	amount, err := strconv.ParseFloat(numberFirstMatches[1], 64)
+	if err != nil {
+		return &IngredientQuantity{Amount: 0, Unit: "適量"}, nil
+	}
+
+	unit := strings.TrimSpace(numberFirstMatches[2])
+	if unit == "" {
+		unit = "個"
+	}
+
+	return &IngredientQuantity{Amount: amount, Unit: unit}, nil
+}
+
+// GetUnitType returns the unit type (weight, volume, count) for a given unit
+func (a *IngredientAggregator) GetUnitType(unit string) string {
+	for unitType, units := range a.unitConversions {
+		if _, exists := units[unit]; exists {
+			return unitType
+		}
+	}
+	return "unknown"
+}
+
+// ConvertToBaseUnit converts quantity to base unit of its type
+func (a *IngredientAggregator) ConvertToBaseUnit(qty *IngredientQuantity) (*IngredientQuantity, error) {
+	if qty.Unit == "適量" {
+		return qty, nil
+	}
+
+	unitType := a.GetUnitType(qty.Unit)
+	if unitType == "unknown" {
+		return qty, nil
+	}
+
+	conversion, exists := a.unitConversions[unitType][qty.Unit]
+	if !exists {
+		return qty, nil
+	}
+
+	baseUnit := a.getBaseUnit(unitType)
+	baseAmount := qty.Amount * conversion
+
+	return &IngredientQuantity{
+		Amount: baseAmount,
+		Unit:   baseUnit,
+	}, nil
+}
+
+// getBaseUnit returns the base unit for each unit type
+func (a *IngredientAggregator) getBaseUnit(unitType string) string {
+	switch unitType {
+	case "weight":
+		return "g"
+	case "volume":
+		return "ml"
+	case "count":
+		return "個"
+	default:
+		return "個"
+	}
+}
+
+// AggregateQuantities aggregates multiple quantities of the same ingredient
+func (a *IngredientAggregator) AggregateQuantities(quantities []*IngredientQuantity) (*IngredientQuantity, error) {
+	if len(quantities) == 0 {
+		return &IngredientQuantity{Amount: 0, Unit: "個"}, nil
+	}
+
+	if len(quantities) == 1 {
+		return quantities[0], nil
+	}
+
+	// Check if any quantity is "適量"
+	for _, qty := range quantities {
+		if qty.Unit == "適量" {
+			return &IngredientQuantity{Amount: 0, Unit: "適量"}, nil
+		}
+	}
+
+	// Convert all to base units
+	baseQuantities := make([]*IngredientQuantity, 0, len(quantities))
+	var targetUnitType string
+
+	for i, qty := range quantities {
+		baseQty, err := a.ConvertToBaseUnit(qty)
+		if err != nil {
+			return &IngredientQuantity{Amount: 0, Unit: "適量"}, err
+		}
+
+		unitType := a.GetUnitType(baseQty.Unit)
+		if i == 0 {
+			targetUnitType = unitType
+		} else if unitType != "unknown" && unitType != targetUnitType {
+			// Different unit types cannot be aggregated
+			return &IngredientQuantity{Amount: 0, Unit: "適量"}, nil
+		}
+
+		baseQuantities = append(baseQuantities, baseQty)
+	}
+
+	// Sum up the base quantities
+	totalAmount := 0.0
+	baseUnit := ""
+	for _, baseQty := range baseQuantities {
+		if baseUnit == "" {
+			baseUnit = baseQty.Unit
+		}
+		totalAmount += baseQty.Amount
+	}
+
+	// Convert back to appropriate display unit
+	result := &IngredientQuantity{Amount: totalAmount, Unit: baseUnit}
+	return a.ConvertToDisplayUnit(result), nil
+}
+
+// ConvertToDisplayUnit converts to user-friendly display unit
+func (a *IngredientAggregator) ConvertToDisplayUnit(qty *IngredientQuantity) *IngredientQuantity {
+	if qty.Unit == "適量" {
+		return qty
+	}
+
+	switch qty.Unit {
+	case "g":
+		if qty.Amount >= 1000 {
+			return &IngredientQuantity{
+				Amount: qty.Amount / 1000,
+				Unit:   "kg",
+			}
+		}
+	case "ml":
+		if qty.Amount >= 1000 {
+			return &IngredientQuantity{
+				Amount: qty.Amount / 1000,
+				Unit:   "l",
+			}
+		}
+	}
+
+	return qty
+}
+
+// FormatQuantity formats a quantity for display
+func (a *IngredientAggregator) FormatQuantity(qty *IngredientQuantity) string {
+	if qty.Unit == "適量" {
+		return "適量"
+	}
+
+	// Format amount based on its value
+	var amountStr string
+	if qty.Amount == float64(int(qty.Amount)) {
+		amountStr = fmt.Sprintf("%.0f", qty.Amount)
+	} else {
+		amountStr = fmt.Sprintf("%.1f", qty.Amount)
+	}
+
+	return fmt.Sprintf("%s%s", amountStr, qty.Unit)
+}

--- a/backend/internal/services/ingredient_aggregator_test.go
+++ b/backend/internal/services/ingredient_aggregator_test.go
@@ -1,0 +1,219 @@
+package services
+
+import (
+	"testing"
+)
+
+func TestNewIngredientAggregator(t *testing.T) {
+	aggregator := NewIngredientAggregator()
+	if aggregator == nil {
+		t.Fatal("Expected non-nil aggregator")
+	}
+}
+
+func TestParseQuantity(t *testing.T) {
+	aggregator := NewIngredientAggregator()
+
+	tests := []struct {
+		input    string
+		expected *IngredientQuantity
+		hasError bool
+	}{
+		{"2個", &IngredientQuantity{Amount: 2, Unit: "個"}, false},
+		{"100g", &IngredientQuantity{Amount: 100, Unit: "g"}, false},
+		{"2.5kg", &IngredientQuantity{Amount: 2.5, Unit: "kg"}, false},
+		{"大さじ1", &IngredientQuantity{Amount: 1, Unit: "大さじ"}, false},
+		{"適量", &IngredientQuantity{Amount: 0, Unit: "適量"}, false},
+		{"少々", &IngredientQuantity{Amount: 0, Unit: "適量"}, false},
+		{"", nil, true},
+		{"2", &IngredientQuantity{Amount: 2, Unit: "個"}, false},
+		{"3 本", &IngredientQuantity{Amount: 3, Unit: "本"}, false},
+	}
+
+	for _, test := range tests {
+		result, err := aggregator.ParseQuantity(test.input)
+
+		if test.hasError {
+			if err == nil {
+				t.Errorf("Expected error for input '%s', but got none", test.input)
+			}
+			continue
+		}
+
+		if err != nil {
+			t.Errorf("Unexpected error for input '%s': %v", test.input, err)
+			continue
+		}
+
+		if result.Amount != test.expected.Amount || result.Unit != test.expected.Unit {
+			t.Errorf("For input '%s', expected %+v, got %+v",
+				test.input, test.expected, result)
+		}
+	}
+}
+
+func TestGetUnitType(t *testing.T) {
+	aggregator := NewIngredientAggregator()
+
+	tests := []struct {
+		unit     string
+		expected string
+	}{
+		{"g", "weight"},
+		{"kg", "weight"},
+		{"ml", "volume"},
+		{"大さじ", "volume"},
+		{"個", "count"},
+		{"本", "count"},
+		{"unknown", "unknown"},
+	}
+
+	for _, test := range tests {
+		result := aggregator.GetUnitType(test.unit)
+		if result != test.expected {
+			t.Errorf("For unit '%s', expected '%s', got '%s'",
+				test.unit, test.expected, result)
+		}
+	}
+}
+
+func TestConvertToBaseUnit(t *testing.T) {
+	aggregator := NewIngredientAggregator()
+
+	tests := []struct {
+		input    *IngredientQuantity
+		expected *IngredientQuantity
+	}{
+		{&IngredientQuantity{Amount: 1, Unit: "kg"}, &IngredientQuantity{Amount: 1000, Unit: "g"}},
+		{&IngredientQuantity{Amount: 2, Unit: "大さじ"}, &IngredientQuantity{Amount: 30, Unit: "ml"}},
+		{&IngredientQuantity{Amount: 3, Unit: "個"}, &IngredientQuantity{Amount: 3, Unit: "個"}},
+		{&IngredientQuantity{Amount: 0, Unit: "適量"}, &IngredientQuantity{Amount: 0, Unit: "適量"}},
+	}
+
+	for _, test := range tests {
+		result, err := aggregator.ConvertToBaseUnit(test.input)
+		if err != nil {
+			t.Errorf("Unexpected error: %v", err)
+			continue
+		}
+
+		if result.Amount != test.expected.Amount || result.Unit != test.expected.Unit {
+			t.Errorf("For input %+v, expected %+v, got %+v",
+				test.input, test.expected, result)
+		}
+	}
+}
+
+func TestAggregateQuantities(t *testing.T) {
+	aggregator := NewIngredientAggregator()
+
+	tests := []struct {
+		name     string
+		input    []*IngredientQuantity
+		expected *IngredientQuantity
+	}{
+		{
+			name: "Same units",
+			input: []*IngredientQuantity{
+				{Amount: 2, Unit: "個"},
+				{Amount: 3, Unit: "個"},
+			},
+			expected: &IngredientQuantity{Amount: 5, Unit: "個"},
+		},
+		{
+			name: "Different weight units",
+			input: []*IngredientQuantity{
+				{Amount: 500, Unit: "g"},
+				{Amount: 1, Unit: "kg"},
+			},
+			expected: &IngredientQuantity{Amount: 1.5, Unit: "kg"},
+		},
+		{
+			name: "Volume units",
+			input: []*IngredientQuantity{
+				{Amount: 2, Unit: "大さじ"},
+				{Amount: 1, Unit: "小さじ"},
+			},
+			expected: &IngredientQuantity{Amount: 35, Unit: "ml"},
+		},
+		{
+			name: "With 適量",
+			input: []*IngredientQuantity{
+				{Amount: 2, Unit: "個"},
+				{Amount: 0, Unit: "適量"},
+			},
+			expected: &IngredientQuantity{Amount: 0, Unit: "適量"},
+		},
+		{
+			name:     "Empty input",
+			input:    []*IngredientQuantity{},
+			expected: &IngredientQuantity{Amount: 0, Unit: "個"},
+		},
+		{
+			name: "Single quantity",
+			input: []*IngredientQuantity{
+				{Amount: 3, Unit: "本"},
+			},
+			expected: &IngredientQuantity{Amount: 3, Unit: "本"},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			result, err := aggregator.AggregateQuantities(test.input)
+			if err != nil {
+				t.Errorf("Unexpected error: %v", err)
+				return
+			}
+
+			if result.Amount != test.expected.Amount || result.Unit != test.expected.Unit {
+				t.Errorf("Expected %+v, got %+v", test.expected, result)
+			}
+		})
+	}
+}
+
+func TestConvertToDisplayUnit(t *testing.T) {
+	aggregator := NewIngredientAggregator()
+
+	tests := []struct {
+		input    *IngredientQuantity
+		expected *IngredientQuantity
+	}{
+		{&IngredientQuantity{Amount: 1500, Unit: "g"}, &IngredientQuantity{Amount: 1.5, Unit: "kg"}},
+		{&IngredientQuantity{Amount: 500, Unit: "g"}, &IngredientQuantity{Amount: 500, Unit: "g"}},
+		{&IngredientQuantity{Amount: 2000, Unit: "ml"}, &IngredientQuantity{Amount: 2, Unit: "l"}},
+		{&IngredientQuantity{Amount: 500, Unit: "ml"}, &IngredientQuantity{Amount: 500, Unit: "ml"}},
+		{&IngredientQuantity{Amount: 0, Unit: "適量"}, &IngredientQuantity{Amount: 0, Unit: "適量"}},
+	}
+
+	for _, test := range tests {
+		result := aggregator.ConvertToDisplayUnit(test.input)
+		if result.Amount != test.expected.Amount || result.Unit != test.expected.Unit {
+			t.Errorf("For input %+v, expected %+v, got %+v",
+				test.input, test.expected, result)
+		}
+	}
+}
+
+func TestFormatQuantity(t *testing.T) {
+	aggregator := NewIngredientAggregator()
+
+	tests := []struct {
+		input    *IngredientQuantity
+		expected string
+	}{
+		{&IngredientQuantity{Amount: 2, Unit: "個"}, "2個"},
+		{&IngredientQuantity{Amount: 1.5, Unit: "kg"}, "1.5kg"},
+		{&IngredientQuantity{Amount: 100, Unit: "g"}, "100g"},
+		{&IngredientQuantity{Amount: 0, Unit: "適量"}, "適量"},
+	}
+
+	for _, test := range tests {
+		result := aggregator.FormatQuantity(test.input)
+		if result != test.expected {
+			t.Errorf("For input %+v, expected '%s', got '%s'",
+				test.input, test.expected, result)
+		}
+	}
+}

--- a/backend/internal/services/meal_planner_ingredient_test.go
+++ b/backend/internal/services/meal_planner_ingredient_test.go
@@ -1,0 +1,160 @@
+package services
+
+import (
+	"testing"
+
+	"lazychef/internal/models"
+)
+
+func TestMealPlannerService_createShoppingList_Aggregation(t *testing.T) {
+	service := &MealPlannerService{
+		ingredientAggregator: NewIngredientAggregator(),
+	}
+
+	// Test recipes with overlapping ingredients
+	recipes := []models.RecipeData{
+		{
+			Title: "Recipe 1",
+			Ingredients: []models.Ingredient{
+				{Name: "卵", Amount: "2個"},
+				{Name: "牛乳", Amount: "200ml"},
+				{Name: "小麦粉", Amount: "100g"},
+			},
+		},
+		{
+			Title: "Recipe 2",
+			Ingredients: []models.Ingredient{
+				{Name: "卵", Amount: "3個"},
+				{Name: "牛乳", Amount: "150ml"},
+				{Name: "砂糖", Amount: "50g"},
+			},
+		},
+	}
+
+	result := service.createShoppingList(recipes)
+
+	// Check results
+	ingredientMap := make(map[string]string)
+	for _, item := range result {
+		ingredientMap[item.Item] = item.Amount
+	}
+
+	// Verify aggregation results
+	tests := []struct {
+		ingredient string
+		expected   string
+	}{
+		{"卵", "5個"},
+		{"牛乳", "350ml"},
+		{"小麦粉", "100g"},
+		{"砂糖", "50g"},
+	}
+
+	for _, test := range tests {
+		amount, exists := ingredientMap[test.ingredient]
+		if !exists {
+			t.Errorf("Expected ingredient '%s' not found in shopping list", test.ingredient)
+			continue
+		}
+		if amount != test.expected {
+			t.Errorf("For ingredient '%s', expected '%s', got '%s'",
+				test.ingredient, test.expected, amount)
+		}
+	}
+
+	// Check total number of items
+	expectedItems := 4
+	if len(result) != expectedItems {
+		t.Errorf("Expected %d items in shopping list, got %d", expectedItems, len(result))
+	}
+}
+
+func TestMealPlannerService_createShoppingList_DifferentUnits(t *testing.T) {
+	service := &MealPlannerService{
+		ingredientAggregator: NewIngredientAggregator(),
+	}
+
+	// Test recipes with different units for same ingredient
+	recipes := []models.RecipeData{
+		{
+			Title: "Recipe 1",
+			Ingredients: []models.Ingredient{
+				{Name: "砂糖", Amount: "100g"},
+			},
+		},
+		{
+			Title: "Recipe 2",
+			Ingredients: []models.Ingredient{
+				{Name: "砂糖", Amount: "1kg"},
+			},
+		},
+	}
+
+	result := service.createShoppingList(recipes)
+
+	// Find sugar in the shopping list
+	var sugarAmount string
+	for _, item := range result {
+		if item.Item == "砂糖" {
+			sugarAmount = item.Amount
+			break
+		}
+	}
+
+	expected := "1.1kg"
+	if sugarAmount != expected {
+		t.Errorf("For aggregated sugar, expected '%s', got '%s'", expected, sugarAmount)
+	}
+}
+
+func TestMealPlannerService_createShoppingList_WithTekiRyou(t *testing.T) {
+	service := &MealPlannerService{
+		ingredientAggregator: NewIngredientAggregator(),
+	}
+
+	// Test recipes with "適量" ingredients
+	recipes := []models.RecipeData{
+		{
+			Title: "Recipe 1",
+			Ingredients: []models.Ingredient{
+				{Name: "塩", Amount: "2g"},
+				{Name: "胡椒", Amount: "適量"},
+			},
+		},
+		{
+			Title: "Recipe 2",
+			Ingredients: []models.Ingredient{
+				{Name: "塩", Amount: "3g"},
+				{Name: "胡椒", Amount: "少々"},
+			},
+		},
+	}
+
+	result := service.createShoppingList(recipes)
+
+	ingredientMap := make(map[string]string)
+	for _, item := range result {
+		ingredientMap[item.Item] = item.Amount
+	}
+
+	// Check results
+	tests := []struct {
+		ingredient string
+		expected   string
+	}{
+		{"塩", "5g"},  // Should aggregate normally
+		{"胡椒", "適量"}, // Should become "適量" when mixed with "適量"/"少々"
+	}
+
+	for _, test := range tests {
+		amount, exists := ingredientMap[test.ingredient]
+		if !exists {
+			t.Errorf("Expected ingredient '%s' not found in shopping list", test.ingredient)
+			continue
+		}
+		if amount != test.expected {
+			t.Errorf("For ingredient '%s', expected '%s', got '%s'",
+				test.ingredient, test.expected, amount)
+		}
+	}
+}


### PR DESCRIPTION
## 概要
Issue #57を解決し、買い物リスト生成時に同じ材料の量を適切に集約する機能を実装しました。

## 解決した問題
`meal_planner.go:81`でTODOとして残っていた材料の量集約処理を完全実装。
これまでは重複する材料は全て「適量」として処理されていましたが、正確な量の合計が表示されるようになりました。

## 実装内容

### 🆕 新規ファイル
- **`ingredient_aggregator.go`**: 材料量解析・集約のコアロジック
- **`ingredient_aggregator_test.go`**: 包括的なテストスイート (13テストケース)
- **`meal_planner_ingredient_test.go`**: MealPlannerServiceとの統合テスト

### 🔧 修正ファイル
- **`meal_planner.go`**: createShoppingList関数を完全書き直し
- **`meal_plan_handler_test.go`**: テスト修正（nil pointer対策）

## 🎯 主要機能

### 1. 日本語量表記解析
```go
"大さじ1" → {Amount: 1, Unit: "大さじ"}
"2.5kg"   → {Amount: 2.5, Unit: "kg"}
"適量"    → {Amount: 0, Unit: "適量"}
```

### 2. 単位変換システム
- **重量**: g ↔ kg, グラム, キロ
- **体積**: ml ↔ l, 大さじ, 小さじ, カップ, 合
- **個数**: 個, 本, 枚, 切れ, パック, 袋, 缶

### 3. 量の集約処理
```
卵 2個 + 卵 3個 → 卵 5個
牛乳 200ml + 牛乳 150ml → 牛乳 350ml
砂糖 100g + 砂糖 1kg → 砂糖 1.1kg
```

### 4. 特殊処理
- 「適量」「少々」が含まれる場合は結果も「適量」
- 異なる単位系の材料は集約不可（「適量」フォールバック）
- パース失敗時の安全なエラーハンドリング

## 🧪 テスト結果
- ✅ **全テスト成功**: 既存テスト含む全テストがパス
- ✅ **品質チェック**: `make quality` 完全成功
- ✅ **回帰テスト**: 既存機能への影響なし

### テスト網羅範囲
- 日本語量表記解析（複数パターン）
- 単位変換・集約処理
- 「適量」「少々」特殊処理
- エラーハンドリング
- MealPlannerService統合

## 📊 実際の効果

### Before (修正前)
```json
{
  "shopping_list": [
    {"item": "卵", "amount": "適量"},
    {"item": "牛乳", "amount": "適量"}
  ]
}
```

### After (修正後)  
```json
{
  "shopping_list": [
    {"item": "卵", "amount": "5個"},
    {"item": "牛乳", "amount": "350ml"},
    {"item": "砂糖", "amount": "1.1kg"}
  ]
}
```

## 🔗 関連Issue
- Closes #57
- 関連: #60 (買い物リスト自動生成機能) - 次のフェーズで実装予定

## Test Plan
- [x] 日本語量表記の正確な解析
- [x] 同一単位材料の量集約
- [x] 異なる単位間の変換・集約
- [x] 「適量」混在時の適切な処理
- [x] エラーケースでの安全なフォールバック
- [x] 既存API機能の回帰確認
- [x] MealPlannerServiceとの統合動作確認

## 📈 技術的改善点
- 型安全性: 構造化されたIngredientQuantity型
- 拡張性: 新しい単位の追加が容易
- 保守性: 包括的なテストカバレッジ
- パフォーマンス: 効率的な集約アルゴリズム

🤖 Generated with [Claude Code](https://claude.ai/code)