### PR TITLE
feat: meal_typeタグの自動追加とUI表示改善

### DIFF
--- a/backend/internal/models/recipe.go
+++ b/backend/internal/models/recipe.go
@@ -157,7 +157,7 @@ func GetRecipeJSONSchema() RecipeSchema {
 				Description: "Recipe tags",
 				Items: &SchemaProperty{
 					Type: "string",
-					Enum: []string{"簡単", "10分以内", "15分以内", "ずぼら", "一品", "和食", "洋食", "中華", "その他"},
+					Enum: []string{"簡単", "10分以内", "15分以内", "ずぼら", "一品", "和食", "洋食", "中華", "主食", "副菜", "汁物", "デザート", "丼・ワンプレート", "常備菜・作り置き", "おやつ・甘味", "その他"},
 				},
 			},
 			"season": {

--- a/backend/internal/services/auto_generation_service.go
+++ b/backend/internal/services/auto_generation_service.go
@@ -429,6 +429,22 @@ func (s *AutoGenerationService) GenerateAutoRecipes(ctx context.Context, req Aut
 			UpdatedAt: time.Now(),
 		}
 
+		// Add meal_type to tags
+		if combo.MealType != nil {
+			mealTypeTag := combo.MealType.DimensionValue
+			// Check if meal_type tag is not already present
+			found := false
+			for _, tag := range recipe.Data.Tags {
+				if tag == mealTypeTag {
+					found = true
+					break
+				}
+			}
+			if !found {
+				recipe.Data.Tags = append(recipe.Data.Tags, mealTypeTag)
+			}
+		}
+
 		// Save recipe to database
 		if err := s.saveRecipeWithDimensions(recipe, combo); err != nil {
 			result.FailedGenerations++

--- a/frontend/src/components/recipe/RecipeCard.tsx
+++ b/frontend/src/components/recipe/RecipeCard.tsx
@@ -83,19 +83,45 @@ const RecipeCard: React.FC<RecipeCardProps> = ({ recipe, onClick }) => {
       {/* タグ */}
       {recipe.tags && recipe.tags.length > 0 && (
         <div className="flex flex-wrap gap-1">
-          {recipe.tags.slice(0, 3).map((tag, index) => (
-            <span 
-              key={index}
-              className="inline-block bg-blue-100 text-blue-700 px-2 py-1 rounded-full text-xs"
-            >
-              #{tag}
-            </span>
-          ))}
-          {recipe.tags.length > 3 && (
-            <span className="inline-block bg-gray-100 text-gray-700 px-2 py-1 rounded-full text-xs">
-              +{recipe.tags.length - 3}
-            </span>
-          )}
+          {(() => {
+            // 基本タグ（全レシピ共通で不要）を除外
+            const excludeBasicTags = ['簡単', '時短', 'ずぼら'];
+            const mealTypeCategories = ['主食', '副菜', '汁物', 'デザート', '丼・ワンプレート', '常備菜・作り置き', 'おやつ・甘味'];
+            
+            // 有用なタグのみをフィルタリング
+            const usefulTags = recipe.tags.filter(tag => !excludeBasicTags.includes(tag));
+            const mealTypeTag = usefulTags.find(tag => mealTypeCategories.includes(tag));
+            const otherUsefulTags = usefulTags.filter(tag => !mealTypeCategories.includes(tag));
+            
+            // meal_typeタグを最初に、その後その他の有用なタグを表示
+            const displayTags = [];
+            if (mealTypeTag) {
+              displayTags.push(mealTypeTag);
+            }
+            displayTags.push(...otherUsefulTags.slice(0, 3)); // meal_typeタグ + 最大3つの追加タグ
+            
+            return (
+              <>
+                {displayTags.map((tag, index) => (
+                  <span 
+                    key={index}
+                    className={`inline-block px-2 py-1 rounded-full text-xs font-medium ${
+                      mealTypeCategories.includes(tag) 
+                        ? 'bg-purple-100 text-purple-800 border border-purple-200' 
+                        : 'bg-blue-100 text-blue-700'
+                    }`}
+                  >
+                    #{tag}
+                  </span>
+                ))}
+                {usefulTags.length > displayTags.length && (
+                  <span className="inline-block bg-gray-100 text-gray-700 px-2 py-1 rounded-full text-xs">
+                    +{usefulTags.length - displayTags.length}
+                  </span>
+                )}
+              </>
+            );
+          })()}
         </div>
       )}
     </div>


### PR DESCRIPTION
## 概要
レシピの分類をより見やすくするため、meal_typeタグの自動追加機能とUI表示を大幅改善しました。

## 主な変更内容

### 🏷️ バックエンド改善
- **自動タグ追加**: レシピ生成時にmeal_typeを自動的にタグに追加
- **タグ許可リスト拡張**: 主食、副菜、汁物、デザート、丼・ワンプレート、常備菜・作り置き、おやつ・甘味を追加
- **重複防止**: 既存タグとの重複チェック機能

### 🎨 フロントエンド改善
- **基本タグ除外**: 全レシピ共通の「簡単・時短・ずぼら」タグを非表示
- **meal_type優先表示**: 紫色背景とボーダーで meal_typeタグを目立たせる
- **スッキリした見た目**: 不要タグを除外して視認性向上

### 💡 ユーザビリティ向上
- **一目で分類把握**: レシピの種類が瞬時に分かる
- **検索性向上**: 意味のあるタグのみ表示
- **自動化**: 手動でのタグ設定が不要

## 実装詳細

### バックエンド
```go
// Add meal_type to tags
if combo.MealType != nil {
    mealTypeTag := combo.MealType.DimensionValue
    // 重複チェックと自動追加
    if !found {
        recipe.Data.Tags = append(recipe.Data.Tags, mealTypeTag)
    }
}
```

### フロントエンド
```tsx
// 基本タグを除外してmeal_typeを優先表示
const excludeBasicTags = ['簡単', '時短', 'ずぼら'];
const mealTypeCategories = ['主食', '副菜', '汁物', 'デザート', '丼・ワンプレート', '常備菜・作り置き', 'おやつ・甘味'];
```

## テスト結果
- ✅ 品質チェック完全合格
- ✅ 全テスト通過 (30.5秒)
- ✅ UI表示確認済み（Playwright）
- ✅ 10件レシピでmeal_typeタグ正常表示

## UI改善前後
**改善前**: `#簡単 #時短 #ずぼら +1` 
**改善後**: `#主食` `#副菜` `#汁物` など意味のあるタグのみ

## バッチ生成APIとの連携
Issue #76のPhase 4バッチ自動生成システムと連携し、生成されるすべてのレシピに適切なmeal_typeタグが自動付与されます。

🤖 Generated with [Claude Code](https://claude.ai/code)